### PR TITLE
Bind on selected event

### DIFF
--- a/src/SketchField.jsx
+++ b/src/SketchField.jsx
@@ -78,6 +78,8 @@ class SketchField extends PureComponent {
     onObjectScaling: PropTypes.func,
     // event object rotating
     onObjectRotating: PropTypes.func,
+    //event object selected
+    onObjectSelected: PropTypes.func,
     // Class name to pass to container div of canvas
     className: PropTypes.string,
     // Style options to pass to container div of canvas
@@ -105,6 +107,7 @@ class SketchField extends PureComponent {
     onObjectMoving:()=>null,
     onObjectScaling:()=>null,
     onObjectRotating:()=>null,
+    onObjectSelected: () => null
   };
 
   state = {
@@ -217,6 +220,11 @@ class SketchField extends PureComponent {
   _onObjectRotating = (e) => {
     const {onObjectRotating} = this.props;
     onObjectRotating(e);
+  };
+
+  _onObjectSelected = e => {
+    const {onObjectSelected} = this.props;
+    onObjectSelected(e);
   };
 
   _onObjectModified = (e) => {
@@ -671,6 +679,7 @@ class SketchField extends PureComponent {
     canvas.on('object:moving', e => this.callEvent(e, this._onObjectMoving));
     canvas.on('object:scaling', e => this.callEvent(e, this._onObjectScaling));
     canvas.on('object:rotating', e => this.callEvent(e, this._onObjectRotating));
+    canvas.on('object:selected', e => this.callEvent(e, this._onObjectSelected));
     // IText Events fired on Adding Text
     // canvas.on("text:event:changed", console.log)
     // canvas.on("text:selection:changed", console.log)


### PR DESCRIPTION
I want to expose this event and then change selection style in our app like so:
```
<SketcField onObjectSelected={handleObjectSelected} ... />

function handleObjectSelected(e) {
const activeObject = e.target;

activeObject.set({
  borderColor: '#687b8c',
  cornerColor: '#687b8c',
  cornerSize: 6,
  cornerStyle: 'circle'
});
}
```

I've verified that it is working as expected in react-sketch playground:
<img width="469" alt="Screenshot 2020-05-19 at 11 45 10" src="https://user-images.githubusercontent.com/29686716/82311958-b35cd000-99c6-11ea-9d4c-b6433da01fd4.png">
